### PR TITLE
data page: Link to Github

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -80,7 +80,7 @@
   <li>ShareAlike: If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.</li>
 </ul>
 
-<p>The source code is published on GitHub</p>
+<p>The source code <a href="https://github.com/nptscot" target="_blank" rel="noopener noreferrer">is published on GitHub</a></p>
 
 
 


### PR DESCRIPTION
The term "is published on Github" now links to Github.