### PR TITLE
Add console.log to show loaded path of files

### DIFF
--- a/src/nptui.js
+++ b/src/nptui.js
@@ -652,6 +652,7 @@ const nptUi = (function () {
 			Object.entries(_datasets.layers).forEach(([layerId, layer]) => {
 				let tileserverUrl = (_settings.tileserverTempLocalOverrides[layerId] ? _settings.tileserverTempLocalOverrides[layerId] : _settings.tileserverUrl);
 				_datasets.layers[layerId].source.url = layer.source.url.replace ('%tileserverUrl', tileserverUrl)
+				console.log (`Setting source.url for layer ${layerId} to ${_datasets.layers[layerId].source.url}`);
 			});
 			
 			// Add layers, and their sources, initially not visible when initialised


### PR DESCRIPTION
This adds some useful logging.

In particular it will help check that the `pmtiles://` protocol is present at the start of the quasi-URL, which is essential to have.

![Screenshot 2024-03-11 at 18 25 30](https://github.com/nptscot/nptscot.github.io/assets/361423/fbad8e44-d761-48e6-ac40-36cc10040880)
