### PR TITLE
391npt coherent colours

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,15 +198,15 @@
 				<p>People cycling per day</p>
 				<div id="slider-cycle-ui" class="slider-styled" data-name="cycle"></div>
 				<datalist list="slider-cycle-ui" data-density="3">
-					<option value="1"     data-position="min"></option>
-					<!-- #!# Should there be a zero value possibility? -->
-					<option value="10"    data-position="12.5%"></option>
-					<option value="50"    data-position="25%"></option>
-					<option value="100"   data-position="37.5%"></option>
-					<option value="250"   data-position="50%"></option>
-					<option value="500"   data-position="65%"></option>
-					<option value="1000"  data-position="80%" data-increments="1000"></option>
-					<option value="20000" data-position="max"></option>
+					<option value="0"     data-position="min"></option>
+					<option value="100"   data-position="12.5%"></option>
+					<option value="250"   data-position="25%"></option>
+					<option value="500"   data-position="37.5%"></option>
+					<option value="1000"  data-position="50%"   data-label="1k"></option>
+					<option value="2500"  data-position="62.5%" data-label="2.5k"></option>
+					<option value="5000"  data-position="75%"   data-label="5k"></option>
+					<option value="10000" data-position="87.5%" data-label="10k"></option>
+					<option value="20000" data-position="max"   data-label="20k"></option>
 					<!-- TODO: Check max value -->
 				</datalist>
 				<input type="hidden" name="cycle" class="updatelayer slider" data-layer="rnet" />

--- a/src/datasets.js
+++ b/src/datasets.js
@@ -119,12 +119,7 @@ const datasets = {
 			},
 			'source-layer': 'cohesivenetwork',
 			'paint': {
-				'line-color': [
-					'match',
-					['get', 'group'],
-					...colourGradient ('#191970', '#b6d0e2', 12)[1],
-					/* other */ 'gray'
-					],
+				'line-color': '#606ca4',
 				'line-width': 2
 			}
 		}
@@ -142,7 +137,9 @@ const datasets = {
 	// #!# These need to be merged with lineColours
 	legends: {
 		
-		cohesivenetwork: colourGradient ('#191970', '#b6d0e2', 12)[0],
+		cohesivenetwork: [
+				['&nbsp;',	'#606ca4']
+		],
 		
 		rnet: {
 			'none': [


### PR DESCRIPTION
This commit removes the gradient as discussed. Obviously it can easily be reinstated later. I have left the gradient generator function in place as it has potential future generic use.

![Screenshot 2024-03-24 at 20 29 44](https://github.com/nptscot/nptscot.github.io/assets/361423/f0a262dc-8e42-470f-b3fb-efe44d825993)
