### PR TITLE
In manual, follow the anchor hash for JS-loaded content; fixes #231

### DIFF
--- a/js/manual.js
+++ b/js/manual.js
@@ -12,6 +12,7 @@ function loadManual ()
     .then (response => response.text ())
     .then (function (text) {
       document.querySelector ('#content').innerHTML = mdToHtml (text);
+      followAnchorHash ();
       createToc ();
       createEditLink ();
     })
@@ -29,6 +30,18 @@ function mdToHtml (mdText)
   return html;
 }
 
+
+// Function to follow the anchor hash for JS-loaded content (which loads after document ready)
+function followAnchorHash ()
+{
+  // Go to hash if present; see: https://stackoverflow.com/a/13736194/180733
+  if (window.location.hash) {
+    if (document.getElementById (window.location.hash.substring (1))) {
+      const top = document.getElementById (window.location.hash.substring (1)).offsetTop;
+      window.scrollTo (0, top);
+    }
+  }
+}
 
 
 // Function to create table of contents


### PR DESCRIPTION
Manual content was moved to loading using .md dynamically.
JS-loaded content is after document ready, so initial location anchor was then failing.
After load, the native browser mechanism will handle in-page clicks as normal.