### PR TITLE
Geocoder improvements #218

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -245,6 +245,10 @@ body .maplibregl-ctrl-geocoder--input {
   height: 35px;
 }
 
+body .maplibregl-ctrl-geocoder--result-address {
+  font-weight: normal;
+}
+
 
 .cookiewarning{
    position: fixed; 

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -645,6 +645,12 @@ const nptUi = (function () {
 			// Assemble the geocoder instance
 			const geocoder = new MaplibreGeocoder (geocoderApi, geocoderOptions);
 			
+			// Auto-close on select; see: https://github.com/maplibre/maplibre-gl-geocoder/issues/183
+			geocoder.on ('result', function () {
+				document.querySelector ('.maplibregl-ctrl-geocoder--button').click ();		// Click to remove the search value
+				document.querySelector ('.maplibregl-ctrl-geocoder--input').blur ();		// Move away from the search box
+			});
+			
 			// Add the control
 			map.addControl (geocoder, position);
 			

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -609,11 +609,12 @@ const nptUi = (function () {
 		// Geocoding API implementation
 		geocoderApi: function ()
 		{
-			const geocoder_api = {
+			// Assemble a MaplibreGeocoderApi implementation; see: https://maplibre.org/maplibre-gl-geocoder/types/MaplibreGeocoderApi.html
+			const geocoderApi = {
 				forwardGeocode: async (config) => {
 					const features = [];
 					try {
-						let request = 'https://nominatim.openstreetmap.org/search?q=' + config.query + '&format=geojson&polygon_geojson=1&addressdetails=1&countrycodes=gb';
+						let request = 'https://nominatim.openstreetmap.org/search?q=' + config.query + '&format=geojson&addressdetails=1&countrycodes=gb';
 						if (_settings.geocoderViewbox) {
 							request += '&viewbox=' + _settings.geocoderViewbox;
 							if (_settings.geocoderBounded) {
@@ -623,23 +624,16 @@ const nptUi = (function () {
 						const response = await fetch(request);
 						const geojson = await response.json();
 						for (let feature of geojson.features) {
-							let center = [
-								feature.bbox[0] + (feature.bbox[2] - feature.bbox[0]) / 2,
-								feature.bbox[1] + (feature.bbox[3] - feature.bbox[1]) / 2
-							];
+							// See: https://web.archive.org/web/20210224184722/https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
 							let point = {
 								type: 'Feature',
-								geometry: {
-									type: 'Point',
-									coordinates: center
-								},
 								place_name: feature.properties.display_name,
 								properties: feature.properties,
 								text: feature.properties.display_name,
 								place_type: ['place'],
-								center: center
+								center: feature.geometry.coordinates
 							};
-							features.push(point);
+							features.push (point);
 						}
 					} catch (e) {
 						console.error (`Failed to forwardGeocode with error: ${e}`);
@@ -651,7 +645,7 @@ const nptUi = (function () {
 				}
 			};
 			
-			return geocoder_api;
+			return geocoderApi;
 		},
 		
 		

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -272,21 +272,7 @@ const nptUi = (function () {
 			maplibregl.addProtocol('pmtiles', protocol.tile);
 			
 			// Add geocoder control; see: https://github.com/maplibre/maplibre-gl-geocoder/blob/main/API.md
-			map.addControl (new MaplibreGeocoder(
-				nptUi.geocoderApi (), {
-					maplibregl: maplibregl,
-					collapsed: true,
-					showResultsWhileTyping: true,
-					minLength: 3,
-					debounceSearch: 400,
-					showResultMarkers: false,
-					marker: false,
-					flyTo: {
-						// #!# Ideally should be bounds: ... but this requires using .on and then result, which means bigger changes
-						zoom: 13
-					}
-				}
-			), 'top-left');
+			map.addControl (nptUi.geocoder (), 'top-left');
 			
 			// Add +/- buttons
 			map.addControl(new maplibregl.NavigationControl(), 'top-left');
@@ -606,10 +592,25 @@ const nptUi = (function () {
 		},
 		
 		
-		// Geocoding API implementation
-		geocoderApi: function ()
+		// Geocoding implementation
+		geocoder: function ()
 		{
-			// Assemble a MaplibreGeocoderApi implementation; see: https://maplibre.org/maplibre-gl-geocoder/types/MaplibreGeocoderApi.html
+			// Define the UI options
+			const geocoderOptions = {
+				maplibregl: maplibregl,
+				collapsed: true,
+				showResultsWhileTyping: true,
+				minLength: 3,
+				debounceSearch: 400,
+				showResultMarkers: false,
+				marker: false,
+				flyTo: {
+					// #!# Ideally should be bounds: ... but this requires using .on and then result, which means bigger changes
+					zoom: 13
+				}
+			};
+			
+			// Implement the data retrieval and assembly; see: https://maplibre.org/maplibre-gl-geocoder/types/MaplibreGeocoderApi.html
 			const geocoderApi = {
 				forwardGeocode: async (config) => {
 					const features = [];
@@ -645,7 +646,8 @@ const nptUi = (function () {
 				}
 			};
 			
-			return geocoderApi;
+			// Return a geocoder instance
+			return new MaplibreGeocoder (geocoderApi, geocoderOptions);
 		},
 		
 		

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -603,11 +603,7 @@ const nptUi = (function () {
 				minLength: 3,
 				debounceSearch: 400,
 				showResultMarkers: false,
-				marker: false,
-				flyTo: {
-					// #!# Ideally should be bounds: ... but this requires using .on and then result, which means bigger changes
-					zoom: 13
-				}
+				marker: false
 			};
 			
 			// Implement the data retrieval and assembly; see: https://maplibre.org/maplibre-gl-geocoder/types/MaplibreGeocoderApi.html
@@ -625,14 +621,14 @@ const nptUi = (function () {
 						const response = await fetch(request);
 						const geojson = await response.json();
 						for (let feature of geojson.features) {
-							// See: https://web.archive.org/web/20210224184722/https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
+							// See: https://maplibre.org/maplibre-gl-geocoder/types/CarmenGeojsonFeature.html and https://web.archive.org/web/20210224184722/https://github.com/mapbox/carmen/blob/master/carmen-geojson.md
 							let point = {
 								type: 'Feature',
 								place_name: feature.properties.display_name,
 								properties: feature.properties,
 								text: feature.properties.display_name,
 								place_type: ['place'],
-								center: feature.geometry.coordinates
+								bbox: feature.bbox
 							};
 							features.push (point);
 						}

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -271,8 +271,8 @@ const nptUi = (function () {
 			let protocol = new pmtiles.Protocol();
 			maplibregl.addProtocol('pmtiles', protocol.tile);
 			
-			// Add geocoder control; see: https://github.com/maplibre/maplibre-gl-geocoder/blob/main/API.md
-			map.addControl (nptUi.geocoder (), 'top-left');
+			// Add geocoder control
+			nptUi.addGeocoder (map, 'top-left');
 			
 			// Add +/- buttons
 			map.addControl(new maplibregl.NavigationControl(), 'top-left');
@@ -593,7 +593,7 @@ const nptUi = (function () {
 		
 		
 		// Geocoding implementation
-		geocoder: function ()
+		addGeocoder: function (map, position)
 		{
 			// Define the UI options
 			const geocoderOptions = {
@@ -642,8 +642,16 @@ const nptUi = (function () {
 				}
 			};
 			
-			// Return a geocoder instance
-			return new MaplibreGeocoder (geocoderApi, geocoderOptions);
+			// Assemble the geocoder instance
+			const geocoder = new MaplibreGeocoder (geocoderApi, geocoderOptions);
+			
+			// Add the control
+			map.addControl (geocoder, position);
+			
+			// Add auto-focus to the widget; see: https://github.com/maplibre/maplibre-gl-geocoder/issues/181 and https://maplibre.org/maplibre-gl-geocoder/classes/default.html#on
+			document.querySelector ('.maplibregl-ctrl-geocoder').addEventListener ('mouseenter', function () {
+				document.querySelector ('.maplibregl-ctrl-geocoder--input').focus ();
+			});
 		},
 		
 		

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -276,6 +276,10 @@ const nptUi = (function () {
 				nptUi.geocoderApi (), {
 					maplibregl: maplibregl,
 					collapsed: true,
+					showResultsWhileTyping: true,
+					minLength: 3,
+					debounceSearch: 400,
+					showResultMarkers: false,
 					marker: false,
 					flyTo: {
 						// #!# Ideally should be bounds: ... but this requires using .on and then result, which means bigger changes


### PR DESCRIPTION
This series of commits adjusts the UI to be more like standard behaviour of a geocoder, addressing items documented in #218 and other related problems.

Previously, the behaviour is the rather odd:

- Click/hover to open the geocoder box
- Click on it again to select it
- Type a name
- Return must be hit, which is not obvious
- A drop-down of options is shown, but the user is unintuitively taken to the first result without actually having selected anything
- The result uses the centre of the feature's bbox; e.g. for Edinburgh it chooses a location south-west of the centre which feels arbitrary
- The user is zoomed in to the fixed zoom of 13
- A marker is left on the screen
- The box stays open even having had the map moved.

Some of the above is the default implementation of this maplibre core plugin. I have submitted [various tickets](https://github.com/maplibre/maplibre-gl-geocoder/issues) encouraging them to make changes.

The updated behaviour is much closer to most other websites:

- Click/hover to open the geocoder box
- The input field is auto-selected
- Search-as-you-type results appear
- The user selects a result
- They are taken to the result
- The map zoom matches the bbox of the feature, e.g. Edinburgh is shown overall (currently there is no maxZoom setting, so an individual street gets a bit too close for my liking, but this is not worse than the previous behaviour of a fixed zoom)
- The box is auto-closed on making a selection.

