### PR TITLE
Fix street space labels; fixes #176

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,8 +264,8 @@
 				<div class="legend">
 					<div class="l_r">
 						<div class="lb"><span style="background-color: #dd7777;"></span>Not enough space</div>
-						<div class="lb"><span style="background-color: #f29551;"></span>Wider than minimum</div>
-						<div class="lb"><span style="background-color: #f9c647;"></span>Wider than absolute minimum</div>
+						<div class="lb"><span style="background-color: #f9c647;"></span>Enough space if built to absolute minimum standard</div>
+						<div class="lb"><span style="background-color: #f29551;"></span>Enough space to build to minimum in CbD</div>
 						<div class="lb"><span style="background-color: #75a375;"></span>Plenty of space</div>
 					</div>
 				</div>


### PR DESCRIPTION
This reverses the order of the two middle items to correct them, and clarifies their meaning.