### PR TITLE
Move layers to proper state model

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -557,6 +557,8 @@ input:checked + .slider:before {
 .layerpopup {
   min-width: 300px;
   max-width: 400px;
+  max-height: 240px;
+  overflow: auto;
 }
 
 .layerpopup table th, .layerpopup table td {

--- a/index.html
+++ b/index.html
@@ -375,31 +375,29 @@
 		
 		<!-- Template for map popup -->
 		<template id="rnet-popup">
-			<p>Cyclists: {_ncycle}</p>
-			<p>Gradient: {gradient}%</p>
-			<p>Cycle-friendliness: {quietness}%</p>
+			<p>Cyclists: {_ncycle}<br />
+			Gradient: {gradient}%<br />
+			Cycle-friendliness: {quietness}%</p>
 			<p><a class="externallink" target="_blank" href="{_streetViewUrl}">Google Street View <i class="fa fa-external-link" aria-hidden="true"></i></a> <a class="externallink" target="_blank" href="{_osmUrl}">OpenStreetMap <i class="fa fa-external-link" aria-hidden="true"></i></a></p>
-			<button class="accordion">All network details</button>
-			<div class="panel" id="popuppanel">
-				<h4>Fast/Direct network</h4>
-				<table>
-					<tr><th></th><th>Baseline</th><th>Go Dutch</th><th>Ebikes</th></tr>
-					<tr><th>All</th><td>{all_fastest_bicycle}</td><td>{all_fastest_bicycle_go_dutch}</td><td>{all_fastest_bicycle_ebike}</td></tr>
-					<tr><th>Commute</th><td>{commute_fastest_bicycle}</td><td>{commute_fastest_bicycle_go_dutch}</td><td>{commute_fastest_bicycle_ebike}</td></tr>
-					<tr><th>Primary</th><td>{primary_fastest_bicycle}</td><td>{primary_fastest_bicycle_go_dutch}</td><td>{primary_fastest_bicycle_ebike}</td></tr>
-					<tr><th>Secondary</th><td>{secondary_fastest_bicycle}</td><td>{secondary_fastest_bicycle_go_dutch}</td><td>{secondary_fastest_bicycle_ebike}</td></tr>
-					<tr><th>Utility</th><td>{utility_fastest_bicycle}</td><td>{utility_fastest_bicycle_go_dutch}</td><td>{utility_fastest_bicycle_ebike}</td></tr>
-				</table>
-				<h4>Quiet/Indirect network</h4>
-				<table>
-					<tr><th></th><th>Baseline</th><th>Go Dutch</th><th>Ebikes</th></tr>
-					<tr><th>All</th><td>{all_quietest_bicycle}</td><td>{all_quietest_bicycle_go_dutch}</td><td>{all_quietest_bicycle_ebike}</td></tr>
-					<tr><th>Commute</th><td>{commute_quietest_bicycle}</td><td>{commute_quietest_bicycle_go_dutch}</td><td>{commute_quietest_bicycle_ebike}</td></tr>
-					<tr><th>Primary</th><td>{primary_quietest_bicycle}</td><td>{primary_quietest_bicycle_go_dutch}</td><td>{primary_quietest_bicycle_ebike}</td></tr>
-					<tr><th>Secondary</th><td>{secondary_quietest_bicycle}</td><td>{secondary_quietest_bicycle_go_dutch}</td><td>{secondary_quietest_bicycle_ebike}</td></tr>
-					<tr><th>Utility</th><td>{utility_quietest_bicycle}</td><td>{utility_quietest_bicycle_go_dutch}</td><td>{utility_quietest_bicycle_ebike}</td></tr>
-				</table>
-			</div>
+			<h3>All network details:</h3>
+			<h4>Fast/Direct network</h4>
+			<table>
+				<tr><th></th><th>Baseline</th><th>Go Dutch</th><th>Ebikes</th></tr>
+				<tr><th>All</th><td>{all_fastest_bicycle}</td><td>{all_fastest_bicycle_go_dutch}</td><td>{all_fastest_bicycle_ebike}</td></tr>
+				<tr><th>Commute</th><td>{commute_fastest_bicycle}</td><td>{commute_fastest_bicycle_go_dutch}</td><td>{commute_fastest_bicycle_ebike}</td></tr>
+				<tr><th>Primary</th><td>{primary_fastest_bicycle}</td><td>{primary_fastest_bicycle_go_dutch}</td><td>{primary_fastest_bicycle_ebike}</td></tr>
+				<tr><th>Secondary</th><td>{secondary_fastest_bicycle}</td><td>{secondary_fastest_bicycle_go_dutch}</td><td>{secondary_fastest_bicycle_ebike}</td></tr>
+				<tr><th>Utility</th><td>{utility_fastest_bicycle}</td><td>{utility_fastest_bicycle_go_dutch}</td><td>{utility_fastest_bicycle_ebike}</td></tr>
+			</table>
+			<h4>Quiet/Indirect network</h4>
+			<table>
+				<tr><th></th><th>Baseline</th><th>Go Dutch</th><th>Ebikes</th></tr>
+				<tr><th>All</th><td>{all_quietest_bicycle}</td><td>{all_quietest_bicycle_go_dutch}</td><td>{all_quietest_bicycle_ebike}</td></tr>
+				<tr><th>Commute</th><td>{commute_quietest_bicycle}</td><td>{commute_quietest_bicycle_go_dutch}</td><td>{commute_quietest_bicycle_ebike}</td></tr>
+				<tr><th>Primary</th><td>{primary_quietest_bicycle}</td><td>{primary_quietest_bicycle_go_dutch}</td><td>{primary_quietest_bicycle_ebike}</td></tr>
+				<tr><th>Secondary</th><td>{secondary_quietest_bicycle}</td><td>{secondary_quietest_bicycle_go_dutch}</td><td>{secondary_quietest_bicycle_ebike}</td></tr>
+				<tr><th>Utility</th><td>{utility_quietest_bicycle}</td><td>{utility_quietest_bicycle_go_dutch}</td><td>{utility_quietest_bicycle_ebike}</td></tr>
+			</table>
 		</template>
 		
 		<!-- Template for map popup -->

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 			<button class="accordion">Route network</button>
 			<div class="panel">
 				<p>
-					<label><input type="checkbox" id="rnetcheckboxproxy" class="rnetproxy" checked="checked" /> Show layer</label>
+					<label><input type="checkbox" id="rnetcheckboxproxy" class="rnetproxy" /> Show layer</label>
 					<!-- These two checkboxes actually control the layers, but are set by the show/simplified checkboxes -->
 					<input type="checkbox" class="showlayer hidden" data-layer="rnet" />
 					<input type="checkbox" class="showlayer hidden" data-layer="rnet-simplified" />

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 			<button class="accordion">Route network</button>
 			<div class="panel">
 				<p>
-					<label><input type="checkbox" id="rnetcheckboxproxy" class="rnetproxy" checked> Show layer</label>
+					<label><input type="checkbox" id="rnetcheckboxproxy" class="rnetproxy" checked="checked" /> Show layer</label>
 					<!-- These two checkboxes actually control the layers, but are set by the show/simplified checkboxes -->
 					<input type="checkbox" class="showlayer hidden" data-layer="rnet" />
 					<input type="checkbox" class="showlayer hidden" data-layer="rnet-simplified" />
@@ -310,7 +310,7 @@
 							<div class="lb"><span style="background-color: #ffffff"></span>&nbsp;</div>
 						</div>
 					</div>
-					<p><label class="switch"><input type="checkbox" name="daysymetricmode" class="updatelayer" data-layer="data_zones" checked><span class="slider round"></span></label> Dasymetric</p>
+					<p><label class="switch"><input type="checkbox" name="daysymetricmode" class="updatelayer" data-layer="data_zones" checked="checked" /><span class="slider round"></span></label> Dasymetric</p>
 				</div>
 			</div>
 			

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -151,7 +151,7 @@ const nptUi = (function () {
 				button.addEventListener ('click', function () {
 					
 					// Toggle between adding and removing the 'active' class, to highlight the button that controls the panel
-					button.classList.toggle('active');
+					button.classList.toggle ('active');
 					
 					// Toggle between hiding and showing the active panel
 					const panel = button.nextElementSibling;
@@ -165,7 +165,7 @@ const nptUi = (function () {
 		layerControlsBoxUi: function ()
 		{
 			// Show the layer controls box
-			showlayercontrols(true);
+			showlayercontrols (true);
 			
 			// Auto-open initial layer sections if required
 			let accordionButtons = [];
@@ -736,8 +736,8 @@ const nptUi = (function () {
 				nptUi.initialiseDatasets ();
 				
 				// Implement initial visibility state for all layers
-				Object.keys(_datasets.layers).forEach(layerId => {
-					nptUi.toggleLayer(layerId);
+				Object.keys (_datasets.layers).forEach (layerId => {
+					nptUi.toggleLayer (layerId);
 				});
 				
 				// Handle layer change controls, each marked with .showlayer or .updatelayer

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -180,11 +180,10 @@ const nptUi = (function () {
 			showlayercontrols(true);
 			
 			// Auto-open initial layer sections if required
-			const initialLayersString =  _hashComponents.layers.replace (new RegExp ('^/'), '').replace (new RegExp ('/$'), '');
-			const initialLayers = (initialLayersString.length ? initialLayersString.split (',') : _settings.initialLayersEnabled);
 			let accordionButtons = [];
-			initialLayers.forEach (function (layerId) {
-				accordionButtons.push (document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').closest ('div.panel').previousElementSibling);
+			const enabledLayers = Object.keys (_state.layers).filter (function (layerId) {return _state.layers[layerId].enabled;});
+			enabledLayers.forEach (function (layerId) {
+					accordionButtons.push (document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').closest ('div.panel').previousElementSibling);
 			});
 			accordionButtons = Array.from (new Set (accordionButtons));	// Remove duplicates - may have more than one layer within a button
 			accordionButtons.forEach (function (accordionButton) {
@@ -241,7 +240,7 @@ const nptUi = (function () {
 			// End if not the intended format of /layers/#map , thus retaining the default state of the _hashComponents property
 			if (hashComponents.length != 2) {return;}
 			
-			// Register the change in the state
+			// Register the change in the hash components state
 			_hashComponents.layers = hashComponents[0];
 			_hashComponents.map = hashComponents[1];
 			//console.log (_hashComponents);

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -861,14 +861,18 @@ const nptUi = (function () {
 			// Create the legend HTML
 			// #!# Should be a list, not nested divs
 			let legendHtml = '<div class="l_r">';
-			legendColours.forEach (legendColour => {
-				if (isRangeType) {legendColour[0] = '≥' + legendColour[0];}
-				legendHtml += `<div class="lb"><span style="background-color: ${legendColour[1]}"></span>${legendColour[0]}</div>`;
-			})
+			legendColours.forEach (function ([value, colour]) {
+				legendHtml += '<div class="lb">';
+				legendHtml += `<span style="background-color: ${colour}">`;
+				legendHtml += '</span>';
+				if (isRangeType) {value = '≥' + value;}
+				legendHtml += value;	// Label
+				legendHtml += '</div>';
+			});
 			legendHtml += '</div>';
 			
 			// Set the legend
-			document.getElementById(selector).innerHTML = legendHtml;
+			document.getElementById (selector).innerHTML = legendHtml;
 		},
 		
 		

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -245,6 +245,11 @@ const nptUi = (function () {
 			_hashComponents.layers = hashComponents[0];
 			_hashComponents.map = hashComponents[1];
 			//console.log (_hashComponents);
+			
+			// Listen for layer state changes
+			document.addEventListener ('@state/change', function () {
+				nptUi.layerStateUrl ();
+			});
 		},
 		
 		
@@ -771,8 +776,9 @@ const nptUi = (function () {
 				nptUi.createLegend (datasets.legends[layerId], layerId + 'legend');
 			}
 			
-			// Set state
+			// Set state of layer
 			_state.layers[layerId].enabled = document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').checked;
+			document.dispatchEvent (new Event ('@state/change', {'bubbles': true}));
 			
 			// Set the visibility of the layer, based on the checkbox value
 			_map.setLayoutProperty (layerId, 'visibility', (_state.layers[layerId].enabled ? 'visible' : 'none'));
@@ -790,9 +796,6 @@ const nptUi = (function () {
 				// Eanble/disable the layer tools div
 				(makeVisibleLayerTools ? layerToolsDiv.classList.add ('enabled') : layerToolsDiv.classList.remove ('enabled'));
 			}
-			
-			// Update the layer state for the URL
-			nptUi.layerStateUrl ();
 		},
 		
 		

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -122,7 +122,12 @@ const nptUi = (function () {
 		// Function to initialise the state
 		initialiseState: function ()
 		{
-			
+			// Initialiase layer state
+			_state.layers = {};
+			Object.keys (_datasets.layers).forEach (function (layerId) {
+				_state.layers[layerId] = {};
+				_state.layers[layerId].enabled = false;
+			});
 		},
 		
 		
@@ -766,16 +771,18 @@ const nptUi = (function () {
 				nptUi.createLegend (datasets.legends[layerId], layerId + 'legend');
 			}
 			
+			// Set state
+			_state.layers[layerId].enabled = document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').checked;
+			
 			// Set the visibility of the layer, based on the checkbox value
-			const makeVisible = document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').checked;
-			_map.setLayoutProperty(layerId, 'visibility', (makeVisible ? 'visible' : 'none'));
+			_map.setLayoutProperty (layerId, 'visibility', (_state.layers[layerId].enabled ? 'visible' : 'none'));
 			
 			// Set the visibility of the layer-specific controls, if present
 			const layerToolsDiv = document.querySelector ('.layertools-' + layerId);
 			if (layerToolsDiv) {
 				
 				// #!# Hacky workaround to deal with rnet/rnet-simplified; without this, the layer tools may not be shown, as one or the other is disabled
-				let makeVisibleLayerTools = makeVisible;
+				let makeVisibleLayerTools = _state.layers[layerId].enabled;
 				if (layerId == 'rnet' || layerId == 'rnet-simplified') {
 					makeVisibleLayerTools = document.querySelector ('input.showlayer[data-layer="' + 'rnet' + '"]').checked || document.querySelector ('input.showlayer[data-layer="' + 'rnet-simplified' + '"]').checked;
 				}
@@ -893,14 +900,8 @@ const nptUi = (function () {
 		// Function to manage layer state URL
 		layerStateUrl: function ()
 		{
-			// Register the IDs of all checked layers, first resetting the list
-			const enabledLayers = [];
-			Object.entries (_datasets.layers).forEach (([layerId, layer]) => {
-				const isEnabled = document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').checked;
-				if (isEnabled) {
-					enabledLayers.push (layerId);
-				}
-			});
+			// Determine enabled layers
+			const enabledLayers = Object.keys (_state.layers).filter (function (key) {return _state.layers[key].enabled;});
 			
 			// Compile the layer state URL
 			const enabledLayersHash = '/' + enabledLayers.join (',') + (enabledLayers.length ? '/' : '');

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -122,11 +122,12 @@ const nptUi = (function () {
 		// Function to initialise the state
 		initialiseState: function ()
 		{
-			// Initialiase layer state
+			// Initialise layer state
 			_state.layers = {};
 			Object.keys (_datasets.layers).forEach (function (layerId) {
-				_state.layers[layerId] = {};
-				_state.layers[layerId].enabled = false;
+				_state.layers[layerId] = {
+					enabled: false
+				};
 			});
 		},
 		
@@ -240,7 +241,7 @@ const nptUi = (function () {
 			// End if not the intended format of /layers/#map , thus retaining the default state of the _hashComponents property
 			if (hashComponents.length != 2) {return;}
 			
-			// Register the change in the hash components state
+			// Register the change in the hash components (for URL) state
 			_hashComponents.layers = hashComponents[0];
 			_hashComponents.map = hashComponents[1];
 			//console.log (_hashComponents);

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -138,10 +138,9 @@ const nptUi = (function () {
 		// Function to manage an accordion
 		accordion: function ()
 		{
-			// Listen for accordion clicks, on a late-bound basis
-			document.addEventListener('click', function (e) {
-				if (e.target.classList.contains('accordion')) {
-					const button = e.target;
+			// Listen for accordion clicks
+			document.querySelectorAll ('button.accordion').forEach  (function (button) {
+				button.addEventListener ('click', function () {
 					
 					// Toggle between adding and removing the 'active' class, to highlight the button that controls the panel
 					button.classList.toggle('active');
@@ -149,7 +148,7 @@ const nptUi = (function () {
 					// Toggle between hiding and showing the active panel
 					const panel = button.nextElementSibling;
 					panel.style.display = (panel.style.display == 'block' ? 'none' : 'block');
-				}
+				});
 			});
 		},	
 		

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -119,37 +119,6 @@ const nptUi = (function () {
 		},
 		
 		
-		// Function to initialise the state
-		initialiseState: function ()
-		{
-			// Initialise layer state structure
-			_state.layers = {};
-			Object.keys (_datasets.layers).forEach (function (layerId) {
-				_state.layers[layerId] = {
-					enabled: false
-				};
-			});
-			
-			// Listen for layer state changes
-			document.addEventListener ('@state/change', function () {
-				nptUi.layerStateUrl ();
-			});
-			
-			// Determine initial layers, preferring URL state if any layers enabled over settings default
-			const initialLayersUrlString = _hashComponents.layers.replace (new RegExp ('^/'), '').replace (new RegExp ('/$'), '');		// Trim start/end slash(es)
-			const initialLayersUrl = (initialLayersUrlString.length ? initialLayersUrlString.split (',') : []);
-			const initialLayers = (initialLayersUrl.length ? initialLayersUrl : _settings.initialLayersEnabled);
-			
-			// Write initial layers specified in the URL, if any, into the state
-			Object.keys (_datasets.layers).forEach (layerId => {
-				_state.layers[layerId].enabled = (initialLayers.includes (layerId));
-			});
-			
-			// Trigger state change
-			document.dispatchEvent (new Event ('@state/change', {'bubbles': true}));
-		},
-		
-		
 		// Welcome screen
 		welcomeScreen: function ()
 		{
@@ -263,6 +232,51 @@ const nptUi = (function () {
 			_hashComponents.layers = hashComponents[0];
 			_hashComponents.map = hashComponents[1];
 			//console.log (_hashComponents);
+		},
+		
+		
+		// Function to initialise the state
+		initialiseState: function ()
+		{
+			// Initialise layer state structure
+			_state.layers = {};
+			Object.keys (_datasets.layers).forEach (function (layerId) {
+				_state.layers[layerId] = {
+					enabled: false
+				};
+			});
+			
+			// Listen for layer state changes
+			document.addEventListener ('@state/change', function () {
+				nptUi.layerStateUrl ();
+			});
+			
+			// Determine initial layers, preferring URL state if any layers enabled over settings default
+			const initialLayersUrlString = _hashComponents.layers.replace (new RegExp ('^/'), '').replace (new RegExp ('/$'), '');		// Trim start/end slash(es)
+			const initialLayersUrl = (initialLayersUrlString.length ? initialLayersUrlString.split (',') : []);
+			const initialLayers = (initialLayersUrl.length ? initialLayersUrl : _settings.initialLayersEnabled);
+			
+			// Write initial layers specified in the URL, if any, into the state
+			Object.keys (_datasets.layers).forEach (layerId => {
+				_state.layers[layerId].enabled = (initialLayers.includes (layerId));
+			});
+			
+			// Trigger state change
+			document.dispatchEvent (new Event ('@state/change', {'bubbles': true}));
+		},
+		
+		
+		// Function to manage layer state URL
+		layerStateUrl: function ()
+		{
+			// Determine enabled layers
+			const enabledLayers = Object.keys (_state.layers).filter (function (key) {return _state.layers[key].enabled;});
+			
+			// Compile the layer state URL
+			const enabledLayersHash = '/' + enabledLayers.join (',') + (enabledLayers.length ? '/' : '');
+			
+			// Register a state change for the URL
+			nptUi.registerUrlStateChange ('layers', enabledLayersHash);
 		},
 		
 		
@@ -905,20 +919,6 @@ const nptUi = (function () {
 			
 			// Set the legend
 			document.getElementById (selector).innerHTML = legendHtml;
-		},
-		
-		
-		// Function to manage layer state URL
-		layerStateUrl: function ()
-		{
-			// Determine enabled layers
-			const enabledLayers = Object.keys (_state.layers).filter (function (key) {return _state.layers[key].enabled;});
-			
-			// Compile the layer state URL
-			const enabledLayersHash = '/' + enabledLayers.join (',') + (enabledLayers.length ? '/' : '');
-			
-			// Register a state change for the URL
-			nptUi.registerUrlStateChange ('layers', enabledLayersHash);
 		},
 		
 		

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -51,8 +51,13 @@ const nptUi = (function () {
 	// Settings
 	let _settings = {};		// Will be populated by constructor
 	let _datasets = {};		// Will be populated by constructor
+	
+	// Properties
 	let _map;
 	let _hashComponents = {layers: '/', map: ''};
+	
+	// State
+	const _state = {};
 	
 	
 	// Functions
@@ -64,6 +69,9 @@ const nptUi = (function () {
 			// Populate the settings and datasets class properties
 			_settings = settings;
 			_datasets = datasets;
+			
+			// Initialise the state
+			nptUi.initialiseState ();
 			
 			// Parse URL hash state
 			nptUi.parseUrl ();
@@ -108,6 +116,13 @@ const nptUi = (function () {
 			
 			// Manage analytics cookie setting
 			nptUi.manageAnalyticsCookie ();
+		},
+		
+		
+		// Function to initialise the state
+		initialiseState: function ()
+		{
+			
 		},
 		
 		

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -246,6 +246,15 @@ const nptUi = (function () {
 			_hashComponents.map = hashComponents[1];
 			//console.log (_hashComponents);
 			
+			// Write initial layers specified in the URL, if any, into the state
+			const initialLayersString = _hashComponents.layers.replace (new RegExp ('^/'), '').replace (new RegExp ('/$'), '');		// Trim start/end slash(es)
+			if (initialLayersString.length) {
+				const initialLayers = initialLayersString.split (',');
+				Object.keys (_datasets.layers).forEach (layerId => {
+					_state.layers[layerId].enabled = (initialLayers.includes (layerId));
+				});
+			}
+			
 			// Listen for layer state changes
 			document.addEventListener ('@state/change', function () {
 				nptUi.layerStateUrl ();
@@ -700,15 +709,6 @@ const nptUi = (function () {
 				
 				// Initialise datasets (sources and layers)
 				nptUi.initialiseDatasets ();
-				
-				// Write initial layers specified in the URL, if any, into the state
-				const initialLayersString = _hashComponents.layers.replace (new RegExp ('^/'), '').replace (new RegExp ('/$'), '');		// Trim start/end slash(es)
-				if (initialLayersString.length) {
-					const initialLayers = initialLayersString.split (',');
-					Object.keys (_datasets.layers).forEach (layerId => {
-						_state.layers[layerId].enabled = (initialLayers.includes (layerId));
-					});
-				}
 				
 				// Set checkboxes
 				Object.entries (_state.layers).forEach (function ([layerId, layer]) {

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -722,18 +722,18 @@ const nptUi = (function () {
 		// Function to manage layers
 		manageLayers: function ()
 		{
+			// Set checkboxes immediately
+			Object.entries (_state.layers).forEach (function ([layerId, layer]) {
+				if (layer.enabled) {
+					document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').checked = true;
+				}
+			});
+			
 			// Add layers when the map is ready (including after a basemap change)
 			document.addEventListener ('@map/ready', function () {
 				
 				// Initialise datasets (sources and layers)
 				nptUi.initialiseDatasets ();
-				
-				// Set checkboxes
-				Object.entries (_state.layers).forEach (function ([layerId, layer]) {
-					if (layer.enabled) {
-						document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').checked = true;
-					}
-				});
 				
 				// Implement initial visibility state for all layers
 				Object.keys(_datasets.layers).forEach(layerId => {

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -790,7 +790,7 @@ const nptUi = (function () {
 				// #!# Hacky workaround to deal with rnet/rnet-simplified; without this, the layer tools may not be shown, as one or the other is disabled
 				let makeVisibleLayerTools = _state.layers[layerId].enabled;
 				if (layerId == 'rnet' || layerId == 'rnet-simplified') {
-					makeVisibleLayerTools = document.querySelector ('input.showlayer[data-layer="' + 'rnet' + '"]').checked || document.querySelector ('input.showlayer[data-layer="' + 'rnet-simplified' + '"]').checked;
+					makeVisibleLayerTools = _state.layers['rnet'].enabled || _state.layers['rnet-simplified'].enabled;
 				}
 				
 				// Eanble/disable the layer tools div

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -701,17 +701,21 @@ const nptUi = (function () {
 				// Initialise datasets (sources and layers)
 				nptUi.initialiseDatasets ();
 				
-				// Set initial visibility based on URL state, by ensuring each such checkbox is ticked
+				// Write initial layers specified in the URL, if any, into the state
 				const initialLayersString = _hashComponents.layers.replace (new RegExp ('^/'), '').replace (new RegExp ('/$'), '');		// Trim start/end slash(es)
 				if (initialLayersString.length) {
 					const initialLayers = initialLayersString.split (',');
 					Object.keys (_datasets.layers).forEach (layerId => {
-						const isEnabled = (initialLayers.includes (layerId));
-						document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').checked = isEnabled;
-						document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').dispatchEvent (new CustomEvent ('change'));
+						_state.layers[layerId].enabled = (initialLayers.includes (layerId));
 					});
 				}
-				document.dispatchEvent (new Event ('@map/initiallayersset', {'bubbles': true}));
+				
+				// Set checkboxes
+				Object.entries (_state.layers).forEach (function ([layerId, layer]) {
+					if (layer.enabled) {
+						document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').checked = true;
+					}
+				});
 				
 				// Implement initial visibility state for all layers
 				Object.keys(_datasets.layers).forEach(layerId => {

--- a/src/settings.js
+++ b/src/settings.js
@@ -81,6 +81,10 @@ function rnetCheckboxProxying ()
 	const rnetCheckbox = document.querySelector ('input.showlayer[data-layer="rnet"]');
 	const rnetsimplifiedCheckbox = document.querySelector ('input.showlayer[data-layer="rnet-simplified"]');
 	
+	// On initial display, set the proxy checkboxes to reflect the underlying real ticked layer boxes (which will have been set in manageLayers)
+	if (rnetCheckbox.checked || rnetsimplifiedCheckbox.checked) {rnetCheckboxProxy.checked = true; /* but do not trigger change, to avoid loop */}
+	if (rnetsimplifiedCheckbox.checked) {rnetsimplifiedCheckboxProxy.checked = true; /* but do not trigger change, to avoid loop */}
+	
 	// Define a function to calculate the real layer checkboxes (rnet/rnet-simplified) values based on the visible (enabled/simplified) boxes which act in combination to determine the visible layer
 	function setRnetCheckboxes ()
 	{
@@ -93,23 +97,11 @@ function rnetCheckboxProxying ()
 		rnetsimplifiedCheckbox.dispatchEvent (new CustomEvent ('change'));
 	}
 	
-	// Set initial state
-	setRnetCheckboxes ();
-	
 	// Change state when the visible UI checkboxes (enabled/simplified) change
 	document.querySelectorAll ('.rnetproxy').forEach ((input) => {
 		input.addEventListener ('change', function (e) {
 			setRnetCheckboxes ();
 		});
-	});
-	
-	// Ensure the visible enabled/simplified boxes are set to match the real checkbox values on initial load due to URL state
-	document.addEventListener ('@map/initiallayersset', function (event) {
-		const layerProxyEnabled = (rnetCheckbox.checked || rnetsimplifiedCheckbox.checked);
-		const simplifiedModeProxyEnabled = rnetsimplifiedCheckbox.checked;
-		rnetCheckboxProxy.checked = (layerProxyEnabled);
-		rnetsimplifiedCheckboxProxy.checked = (layerProxyEnabled && simplifiedModeProxyEnabled);
-		// Events are not dispatched, to avoid event loop
 	});
 }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -81,7 +81,7 @@ function rnetCheckboxProxying ()
 	const rnetCheckbox = document.querySelector ('input.showlayer[data-layer="rnet"]');
 	const rnetsimplifiedCheckbox = document.querySelector ('input.showlayer[data-layer="rnet-simplified"]');
 	
-	// Define a function to calculate the real checkbox values based on the enabled/simplified boxes
+	// Define a function to calculate the real layer checkboxes (rnet/rnet-simplified) values based on the visible (enabled/simplified) boxes which act in combination to determine the visible layer
 	function setRnetCheckboxes ()
 	{
 		// Calculate the real checkbox values based on the enabled/simplified boxes
@@ -96,7 +96,7 @@ function rnetCheckboxProxying ()
 	// Set initial state
 	setRnetCheckboxes ();
 	
-	// Change state when the visible UI checkboxes change
+	// Change state when the visible UI checkboxes (enabled/simplified) change
 	document.querySelectorAll ('.rnetproxy').forEach ((input) => {
 		input.addEventListener ('change', function (e) {
 			setRnetCheckboxes ();


### PR DESCRIPTION
This commit replaces the core layer management.

The original code originally inherited by the project worked on the basis of managing the layers (and thus the URL state) by reading and (for the URL state) directly manipulating the checkboxes. In other words, the state was being stored in the DOM. This approach has limitations and is not nowadays considered best practice.

This commit changes this to manage the state in a proper `state` object. The map layers, URLs, and checkboxes then react and manipulate that state object, or vice versa. This is a better design pattern.

This commit is a necessary precondition to getting the per-layer URL state in place. The state object can now be extended to store the control values related to each layer.