### PR TITLE
Load build file

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
 		<!-- NPT application -->
 		<script src="src/settings.js"></script>
 		<script src="src/datasets.js"></script>
+		<!-- src/build.json will also be loaded, as a required file -->
 		<script src="src/nptui.js"></script>
 		<script>
 			document.addEventListener ('DOMContentLoaded', function () {
@@ -100,8 +101,7 @@
 				<p>The results are publicly available. The main intended audience is local authorities undertaking cycle network planning to support  evidence-based and transparent investment, scheme location and design decisions.</p>
 				<p>Last updated: <span id="updatedate"></span>. You may need to <a href="https://www.minitool.com/news/f5-vs-ctrl-f5.html">clear your browser cache</a> to see the latest updates.</p>
 				<p>To report issues or provide feedback, please use the <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=qO3qvR3IzkWGPlIypTW3ywVZfmO0bwdAhK0UztpneQtUM1pCRlJQQjY1V0M3MUhBV0g0VTJRS1ZQVi4u" target="_blank">feedback form</a>.</p>
-				<p>Date of OSM Data on which network results are based:</p>
-				<p id="osmupdatedate"></p>
+				<p>Date of OSM data on which network results are based: <span id="osmupdatedate"></span>.</p>
 				<p id="logos">
 					<a href="https://environment.leeds.ac.uk/transport" target="_blank"><img src="/images/logos/leeds.png" alt="University of Leeds" /></a>
 					<a href="https://www.sustrans.org.uk/about-us/our-work-in-scotland" target="_blank"><img src="/images/logos/sustrans.png" alt="Sustrans" /></a>

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -50,6 +50,7 @@ const nptUi = (function () {
 	
 	// Settings
 	let _settings = {};		// Will be populated by constructor
+	let _build = {};		// Will be populated by constructor
 	let _datasets = {};		// Will be populated by constructor
 	
 	// Properties
@@ -66,9 +67,26 @@ const nptUi = (function () {
 		// Main function
 		initialise: function (settings, datasets)
 		{
+			// Load the build data then run the constructor
+			fetch ('/src/build.json')
+				.then (function (response) {return response.json ();})
+				.then (function (data) {
+					_build = data;
+					nptUi.construct (settings, datasets);
+				})
+				.catch (function (error) {
+					console.error ('Error loading build data - could not run application:', error);
+				});
+		},
+		
+		
+		// Constructor
+		construct: function (settings, datasets)
+		{
 			// Populate the settings and datasets class properties
 			_settings = settings;
 			_datasets = datasets;
+			// _build will have been loaded
 			
 			// Parse URL hash state
 			nptUi.parseUrl ();
@@ -132,7 +150,7 @@ const nptUi = (function () {
 			
 			// Set OSM and update dates in the text, if present
 			if (document.getElementById ('osmupdatedate')) {
-				document.getElementById ('osmupdatedate').innerHTML = _settings.osmDate;
+				document.getElementById ('osmupdatedate').innerHTML = nptUi.formatAsUKDate (_build.osmDate);
 			}
 			if (document.getElementById ('updatedate')) {
 				document.getElementById ('updatedate').innerText = nptUi.formatAsUKDate (document.lastModified);

--- a/src/settings.js
+++ b/src/settings.js
@@ -58,9 +58,6 @@ const settings = {
 	// Boundaries
 	boundariesUrl: 'https://nptscot.github.io/scheme-sketcher/assets/boundaries-3d573d2e.geojson',
 	
-	// OSM data date
-	osmDate: '1 Jan 2025',
-	
 	// Analytics
 	gaProperty: 'G-QZMHV92YXJ',
 	
@@ -68,7 +65,7 @@ const settings = {
 	uiCallback: rnetCheckboxProxying,	// Defined below
 	
 	// Initial layers enabled
-	initialLayersEnabled: ['rnet'],
+	initialLayersEnabled: ['rnet']
 };
 
 
@@ -105,4 +102,3 @@ function rnetCheckboxProxying ()
 	});
 }
 
-		


### PR DESCRIPTION
Replacement fix for #312.

The key issue with 312 is that it added in the settings file asyncronously. That means that the contents of the file may well not be available at the point that the welcome screen is shown.

This must therefore be loaded as a required data file, i.e. using fetch.

Syncronous loading will produce a warning as it blocks the UI through, though the effect of wrapping the logic in a fetch call is essentially the same but the proper way to do it.

The data cannot be loaded in a <script> tag as per e.g. the settings.js file, because this is not a .js file - it is a JSON file, i.e. not a script file.

NB I have renamed it to `build.json` - please ensure the upstream creation process is aware.