### PR TITLE
Existing infrastructure: adjust lane thickness down; fixes #365

### DIFF
--- a/src/datasets.js
+++ b/src/datasets.js
@@ -290,7 +290,7 @@ const datasets = {
 						'Off Road Cycleway': 4,
 						'Segregated Track (narrow)': 4,
 						'Shared Footway': 3,
-						'Painted Cycle Lane': 1,
+						'Painted Cycle Lane': 1.8,
 						'_': 2,
 					}
 				}

--- a/src/datasets.js
+++ b/src/datasets.js
@@ -290,7 +290,7 @@ const datasets = {
 						'Off Road Cycleway': 4,
 						'Segregated Track (narrow)': 4,
 						'Shared Footway': 3,
-						'Painted Cycle Lane': 3,
+						'Painted Cycle Lane': 1,
 						'_': 2,
 					}
 				}


### PR DESCRIPTION
Tones down cycle lanes so they are thin and non-prominent, compared to the much thicker real infrastructure lines. Big improvement I think.

Fixes #365.

![Screenshot 2025-03-23 at 19 00 49](https://github.com/user-attachments/assets/78af7b87-6189-4463-aa67-88b3bed01df2)
