### PR TITLE
264 per layer checkboxes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -464,6 +464,7 @@ p.help-end {
 .legend div span input[type="checkbox"].legendfilter {
   display: block;
   text-align: left;
+  opacity: 0.65;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
 						</select>
 						Line colour <button aria-label="Help colour" class="helpbutton" data-help="colour" title="Full details of colouring of route lines"><i class="fa fa-question-circle" aria-hidden="true"></i></button>
 					</p>
-					<div class="legend" id="legend-rnet"></div>
+					<div class="legend nonfilterable" id="legend-rnet"></div>
 					
 					<p><b>Filter to:</b><button aria-label="Help scenario" class="helpbutton" data-help="filters" title="Full details of filtering parts of the route network"><i class="fa fa-question-circle" aria-hidden="true"></i></button></p>
 					<table class="filters">

--- a/src/datasets.js
+++ b/src/datasets.js
@@ -239,6 +239,7 @@ const datasets = {
 				'line-width': 3
 			},
 		},
+		filtering: 'road_function_npt',
 	},
 	
 	clos: {
@@ -639,6 +640,7 @@ const datasets = {
 				'circle-stroke-width': 1
 			}
 		},
+		filtering: 'SchoolType',
 		/*
 		,
 		// Travel to School Modeshare

--- a/src/datasets.js
+++ b/src/datasets.js
@@ -99,6 +99,8 @@ const datasets = {
 		// Layer styling callbacks function, defined at the end
 		layerStyling: fooStyling,
 		
+		// For checkbox filtering, which field in the internal layer is in use; this is not necessary if using sublayers
+		filtering: 'internal_field_name',
 		
 		// Legend labels
 		// - If not present, legends will be auto-generated from the sublayers paint or (if not sublayers) the main definition paint

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -1165,7 +1165,8 @@ const nptUi = (function () {
 		{
 			// Do nothing if no selector for where the legend will be added
 			const selector = 'legend-' + layerId;
-			if (!document.getElementById (selector)) {return;}
+			const legendEl = document.getElementById (selector);
+			if (!legendEl) {return;}
 			
 			// Determine sublayer
 			let sublayerId = null;
@@ -1181,7 +1182,7 @@ const nptUi = (function () {
 			const field = (sublayerId ? sublayerId : _datasets[layerId].filtering);
 			
 			// Determine whether to show checkboxes; do not show if only 1 value
-			const showCheckboxes = (field && (Object.values (legends).length > 1));
+			const showCheckboxes = (!legendEl.classList.contains ('nonfilterable') && field && (Object.values (legends).length > 1));
 			
 			// Create the legend HTML
 			// #!# Should be a list, not nested divs
@@ -1203,7 +1204,7 @@ const nptUi = (function () {
 			legendHtml += '</div>';
 			
 			// Set the legend
-			document.getElementById (selector).innerHTML = legendHtml;
+			legendEl.innerHTML = legendHtml;
 			
 			// Trigger change to ensure filtering
 			if (showCheckboxes) {

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -1085,9 +1085,6 @@ const nptUi = (function () {
 				_datasets[layerId].layerStyling (layerId, _map, _settings, _datasets);
 			}
 			
-			// Reset any existing filtering, e.g. checkbox filters
-			_map.setFilter (layerId, null);
-			
 			// Create/update legend (even if map layer is off)
 			nptUi.createLegend (layerId);
 			
@@ -1208,6 +1205,7 @@ const nptUi = (function () {
 			
 			// Trigger change to ensure filtering
 			if (showCheckboxes) {
+				_map.setFilter (layerId, null);	// Reset any existing filtering, e.g. checkbox filters
 				document.querySelector ('.legendfilter[name="legendfilter_' + layerId + '"]').dispatchEvent (new Event ('change', {bubbles: true}));		// Arbitrary checkbox in the set
 			}
 		},

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -1247,11 +1247,11 @@ const nptUi = (function () {
 									// Start a list of filters for this checkbox
 									const thisCheckboxFilters = [];
 									
-									// Set the upper range
+									// Set the lower range
 									const thisValue = checkbox.value;
 									thisCheckboxFilters.push (['>=', ['get', field], Number (thisValue)]);
 									
-									// If a next value, set the lower range
+									// If a next value, set the upper range
 									const nextValue = allCheckboxValues[index + 1];
 									if (nextValue) {
 										thisCheckboxFilters.push (['<', ['get', field], Number (nextValue)]);
@@ -1259,6 +1259,8 @@ const nptUi = (function () {
 									
 									// Combine the filter(s) for this checkbox
 									const thisCheckboxFilter = ['all', ...thisCheckboxFilters];
+									
+									// Register the combined filter for this checkbox
 									filters.push (thisCheckboxFilter);
 								}
 							});

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -1008,8 +1008,12 @@ const nptUi = (function () {
 			// Use the first defined style (only) as the basis for the legend
 			let style = Object.values (styleSpec)[0];
 			
+			// Determine the type
+			let type;
+			
 			// If the style is a string (rather than an expression), convert to array structure
 			if (!Array.isArray (style)) {
+				type = 'scalar';
 				style = ['', style];	// Label unknown at this point
 			}
 			
@@ -1018,6 +1022,7 @@ const nptUi = (function () {
 			
 			// For match, remove unwanted tokens, leaving only [value, colour, value, colour, ...] adjacent values; see: https://docs.mapbox.com/style-spec/reference/expressions/#match
 			if (styleTokens[0] == 'match') {
+				type = 'match';
 				styleTokens.shift ();	// Remove 'match'
 				styleTokens.shift ();	// Remove ['get', ...]
 				styleTokens.pop ();		// Remove fallback value, which is at the end of the array
@@ -1025,17 +1030,20 @@ const nptUi = (function () {
 			
 			// For step, remove unwanted tokens, leaving only [value, colour, value, colour, ...] values; see: https://docs.mapbox.com/style-spec/reference/expressions/#step
 			if (styleTokens[0] == 'step') {
+				type = 'step';
 				styleTokens.shift ();	// Remove 'step'
 				styleTokens.shift ();	// Remove ['get', ...]
 				styleTokens.shift ();	// Remove the infinite-lower-bound value (e.g. 0) colour at the start
 			}
 			
-			// Convert adjacent values to pairs, e.g. [a, 0, b, 1, c, 2] becomes [[a, 0], [b, 1], [c, 2]]
+			// Convert adjacent values to pairs, e.g. [a, 0, b, 1, c, 2] becomes [[a, 0], [b, 1], [c, 2]], but also store the original value and type for use in filtering
 			const legends = [];
 			for (let i = 0; i < styleTokens.length - 1; i += 2) {
 				legends.push ([
 					styleTokens[i],		// Label (original value)
-					styleTokens[i + 1]	// Colour
+					styleTokens[i + 1],	// Colour
+					styleTokens[i],		// Original value; will be empty if only one value
+					type				// Type: scalar/match/step
 				]);
 			}
 			
@@ -1082,6 +1090,9 @@ const nptUi = (function () {
 			// Set state of layer
 			_state.layers[layerId].enabled = document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').checked;
 			document.dispatchEvent (new Event ('@state/change', {'bubbles': true}));
+			
+			// Reset any existing filtering, e.g. checkbox filters
+			_map.setFilter (layerId, null);
 			
 			// Set the visibility of the layer, based on the checkbox value
 			_map.setLayoutProperty (layerId, 'visibility', (_state.layers[layerId].enabled ? 'visible' : 'none'));
@@ -1165,12 +1176,21 @@ const nptUi = (function () {
 			// Use the static legends, unless there is a sublayer selector for which the sublayer legends need to be looked up
 			const legends = (sublayerId ? (_datasets[layerId].legends[sublayerId] || _datasets[layerId].legends['_']) : _datasets[layerId].legends[layerId]);
 			
+			// Determine the field for filtering, either the layer's main internal layer or a sublayer
+			const field = (sublayerId ? sublayerId : _datasets[layerId].filtering);
+			
+			// Determine whether to show checkboxes; do not show if only 1 value
+			const showCheckboxes = (field && (Object.values (legends).length > 1));
+			
 			// Create the legend HTML
 			// #!# Should be a list, not nested divs
 			let legendHtml = '<div class="l_r">';
-			legends.forEach (function ([label, colour]) {
+			legends.forEach (function ([label, colour, value, type]) {
 				legendHtml += '<div class="lb">';
 				legendHtml += `<span style="background-color: ${colour}">`;
+				if (showCheckboxes) {
+					legendHtml += `<input type="checkbox" checked="checked" class="legendfilter" name="legendfilter_${layerId}" data-field="${field}" value="${value}" data-type="${type}" />`;
+				}
 				legendHtml += '</span>';
 				legendHtml += label;
 				legendHtml += '</div>';
@@ -1192,15 +1212,29 @@ const nptUi = (function () {
 					
 					// Determine the layer and its field to filter on
 					const layerId = checkbox.name.replace ('legendfilter_', '');
-					const field = _datasets[layerId].layer._filtering;
+					const field = checkbox.dataset.field;
+					const type = checkbox.dataset.type;
+					
+					// Get the all the checkboxes
+					const allCheckboxes = [...document.querySelectorAll ('input[type="checkbox"][class="legendfilter"][name="legendfilter_' + layerId + '"]')];
 					
 					// Get all the checkboxes that are checked for this layer
-					const checkedInLayer = [...document.querySelectorAll ('input[type="checkbox"][class="legendfilter"][name="legendfilter_' + layerId + '"]')]
+					const checkedInLayer = allCheckboxes
 						.filter ((el) => el.checked)
-						.map ((el) => el.value)
+						.map ((el) => (el.value.match (/^[0-9]+$/) ? Number (el.value) : el.value));
 					
-					// Filter
-					_map.setFilter (layerId, ['in', field, ...checkedInLayer]);
+					// Set the filter; see: https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setfilter
+					let filter;
+					switch (type) {
+						
+						// Match: Filter to those checkboxes in the layer
+						case 'match':
+							filter = ['in', field, ...checkedInLayer];
+							break;
+					}
+					
+					// Set the filter
+					_map.setFilter (layerId, filter);
 				}
 			});
 		},

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -1231,6 +1231,41 @@ const nptUi = (function () {
 						case 'match':
 							filter = ['in', field, ...checkedInLayer];
 							break;
+							
+						// Step: Filter to values which are within the ranges of the selected checkboxes, from the current to next value
+						case 'step':
+							
+							// Get all the values of the checkboxes, indexed by checkbox index, to use as a lookup to get the following checkbox
+							const allCheckboxValues = allCheckboxes.map ((el) => el.value);
+							
+							// Set a filter for each checked value, creating a range from the previous checkbox to the current
+							// E.g. if a ticked percentiles list is 1st, 3rd, 7th, 10th, then value must be within 0-1 / 2-3 / 6-7 / 9-10
+							const filters = [];
+							allCheckboxes.forEach (function (checkbox, index) {
+								if (checkbox.checked) {
+									
+									// Start a list of filters for this checkbox
+									const thisCheckboxFilters = [];
+									
+									// Set the upper range
+									const thisValue = checkbox.value;
+									thisCheckboxFilters.push (['>=', ['get', field], Number (thisValue)]);
+									
+									// If a next value, set the lower range
+									const nextValue = allCheckboxValues[index + 1];
+									if (nextValue) {
+										thisCheckboxFilters.push (['<', ['get', field], Number (nextValue)]);
+									}
+									
+									// Combine the filter(s) for this checkbox
+									const thisCheckboxFilter = ['all', ...thisCheckboxFilters];
+									filters.push (thisCheckboxFilter);
+								}
+							});
+							
+							// Set the filter set
+							filter = ['any', ...filters];
+							break;
 					}
 					
 					// Set the filter

--- a/src/nptui.js
+++ b/src/nptui.js
@@ -57,6 +57,7 @@ const nptUi = (function () {
 	// Properties
 	let _map;
 	let _hashComponents = {layers: '/', map: ''};
+	let _filters = {};
 	
 	// State
 	const _state = {};
@@ -1084,15 +1085,15 @@ const nptUi = (function () {
 				_datasets[layerId].layerStyling (layerId, _map, _settings, _datasets);
 			}
 			
+			// Reset any existing filtering, e.g. checkbox filters
+			_map.setFilter (layerId, null);
+			
 			// Create/update legend (even if map layer is off)
 			nptUi.createLegend (layerId);
 			
 			// Set state of layer
 			_state.layers[layerId].enabled = document.querySelector ('input.showlayer[data-layer="' + layerId + '"]').checked;
 			document.dispatchEvent (new Event ('@state/change', {'bubbles': true}));
-			
-			// Reset any existing filtering, e.g. checkbox filters
-			_map.setFilter (layerId, null);
 			
 			// Set the visibility of the layer, based on the checkbox value
 			_map.setLayoutProperty (layerId, 'visibility', (_state.layers[layerId].enabled ? 'visible' : 'none'));
@@ -1189,7 +1190,11 @@ const nptUi = (function () {
 				legendHtml += '<div class="lb">';
 				legendHtml += `<span style="background-color: ${colour}">`;
 				if (showCheckboxes) {
-					legendHtml += `<input type="checkbox" checked="checked" class="legendfilter" name="legendfilter_${layerId}" data-field="${field}" value="${value}" data-type="${type}" />`;
+					let isChecked = true;	// All on by default, unless state available from a previous interaction
+					if (_filters.hasOwnProperty (layerId) && _filters[layerId].hasOwnProperty (field)) {
+						isChecked = _filters[layerId][field].includes (value);
+					}
+					legendHtml += '<input type="checkbox"' + (isChecked ? ' checked="checked"' : '') + ` class="legendfilter" name="legendfilter_${layerId}" data-field="${field}" value="${value}" data-type="${type}" />`;
 				}
 				legendHtml += '</span>';
 				legendHtml += label;
@@ -1199,6 +1204,11 @@ const nptUi = (function () {
 			
 			// Set the legend
 			document.getElementById (selector).innerHTML = legendHtml;
+			
+			// Trigger change to ensure filtering
+			if (showCheckboxes) {
+				document.querySelector ('.legendfilter[name="legendfilter_' + layerId + '"]').dispatchEvent (new Event ('change', {bubbles: true}));		// Arbitrary checkbox in the set
+			}
 		},
 		
 		
@@ -1223,7 +1233,12 @@ const nptUi = (function () {
 						.filter ((el) => el.checked)
 						.map ((el) => (el.value.match (/^[0-9]+$/) ? Number (el.value) : el.value));
 					
-					// Set the filter; see: https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setfilter
+					// Save the checkbox state; initialisation of the structure is done only on change, so that an empty set represents explicitly chosen to be empty
+					if (!_filters.hasOwnProperty (layerId)) {_filters[layerId] = {};}
+					if (!_filters[layerId].hasOwnProperty (field)) {_filters[layerId][field] = {};}
+					_filters[layerId][field] = checkedInLayer;
+					
+					// Set the filter based on the checkbox state; see: https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setfilter
 					let filter;
 					switch (type) {
 						


### PR DESCRIPTION
This implements layer checkboxes.

These are generated generically, except where disabled (rnet/rnet-simplified). So they will appear for all legends by default.

Not yet saved into URL state.