### PR TITLE
Better scroll CSS for popups; fixes #460

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -576,7 +576,10 @@ body .maplibregl-map {line-height: 1.4;}
   min-width: 350px;
   max-width: 400px;
   max-height: 340px;
-  overflow: auto;
+}
+
+.layerpopup .maplibregl-popup-content {
+  overflow-y: auto;
 }
 
 .layerpopup table th, .layerpopup table td {


### PR DESCRIPTION
This should fix #460 as it shifts the scroll to a more specific element.

![Image](https://github.com/user-attachments/assets/b9203b98-a74b-49ba-b172-a036d89438b9)