### PR TITLE
Fix #469: Add build script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "url": "https://github.com/nptscot/nptscot.github.io/issues"
   },
   "homepage": "https://npt.scot",
+  "scripts": {
+    "build": "echo \"No build specified\""
+  },
   "dependencies": {
     "nouislider": "^15.7.0"
   }


### PR DESCRIPTION
This PR fixes issue #469 by adding a build script to package.json to resolve the Azure deployment failure.